### PR TITLE
Fixed bug with solution folders + project list is now sorted by name.

### DIFF
--- a/CommonResources/ConnectionPane.xaml.cs
+++ b/CommonResources/ConnectionPane.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
@@ -20,6 +21,8 @@ namespace CommonResources
         private readonly Solution _solution;
         private readonly Logger _logger;
         private bool _connectionAdded;
+
+        const string SolutionFolder = "{66A26720-8FB5-11D2-AA7E-00C04F688DDE}";
 
         public event EventHandler ProjectChanged;
         public event EventHandler<ConnectionSelectedEventArgs> ConnectionSelected;
@@ -133,7 +136,7 @@ namespace CommonResources
             AddConnection.IsEnabled = true;
             Connections.IsEnabled = true;
 
-            foreach (Project project in Projects)
+            foreach (var project in Projects.Cast<Project>().OrderBy(x => x.FullName))
             {
                 SolutionProjectAdded(project);
             }
@@ -144,6 +147,9 @@ namespace CommonResources
             //Don't want to include the VS Miscellaneous Files Project - which appears occasionally and during a diff operation
             if (project.Name.ToUpper() == "MISCELLANEOUS FILES")
                 return;
+
+            // Exclude solution folders 
+            if (project.Kind != null && project.Kind.ToUpper() == SolutionFolder) return;
 
             bool addProject = true;
             foreach (ComboBoxItem projectItem in ProjectsDdl.Items)


### PR DESCRIPTION
In case if solution contains folders, there was exception in line 204,
because FullName property is empty and all next projects were not in list.

Actually it's not good, big solutions can contain many projects in different solution folders. In these cases we will see only projects in solution root. I made this quick fix because any solution with at least one folder didn't load correctly. Probably connection pane should be reworked in the future to support projects in folders.