### PR TITLE
Fixed Window Being Reset When Deactivated

### DIFF
--- a/CommonResources/ConnectionPane.xaml
+++ b/CommonResources/ConnectionPane.xaml
@@ -5,8 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.11.0"
              mc:Ignorable="d" 
-             d:DesignHeight="150" d:DesignWidth="203"
-             Unloaded="ConnectionPane_OnUnloaded">
+             d:DesignHeight="150" d:DesignWidth="203">
     <Expander x:Name="Expander"  HorizontalAlignment="Left" Margin="5,5,0,0" VerticalAlignment="Top" ExpandDirection="Right" IsExpanded="True" Foreground="{DynamicResource {x:Static vsfx:VsBrushes.ToolWindowTextKey}}">
         <Expander.Header>
             <TextBlock Text="Connections">

--- a/CommonResources/ConnectionPane.xaml.cs
+++ b/CommonResources/ConnectionPane.xaml.cs
@@ -105,11 +105,6 @@ namespace CommonResources
             Projects = _dte.Solution.Projects;
         }
 
-        private void ConnectionPane_OnUnloaded(object sender, RoutedEventArgs e)
-        {
-            ResetForm();
-        }
-
         private void BeforeSolutionClosing()
         {
             ResetForm();


### PR DESCRIPTION
This change fixes a bug that I found when a window is unloaded.

Steps to reproduce:
1. Open Web Resource Deployer
2. Connect to Organization
3. Switch to another tab in the same window of visual studio (I switched to the Output tab in my testing)
4. Switch back to Web Resource Deployer tab.

Result:
The web resource deployer window is no longer connected to the organization. This makes the window appear to be unresponsive.

When the output window is opened, the Unloaded event is fired on the Connection Pane, resetting the form.