### PR TITLE
Fixed issue where projects in solution folders aren't displayed corre…

### DIFF
--- a/CommonResources/ConnectionPane.xaml.cs
+++ b/CommonResources/ConnectionPane.xaml.cs
@@ -131,51 +131,12 @@ namespace CommonResources
             AddConnection.IsEnabled = true;
             Connections.IsEnabled = true;
 
-            foreach (var project in GetProjects())
+            foreach (var project in SharedWindow.GetProjects(_dte.Solution.Projects))
             {
                 SolutionProjectAdded(project);
             }
         }
-
-        private IEnumerable<Project> GetProjects()
-        {
-            var list = new List<Project>();
-            var item = _dte.Solution.Projects.GetEnumerator();
-
-            while (item.MoveNext())
-            {
-                var project = item.Current as Project;
-
-                if (project == null) continue;
-
-                if (project.Kind.ToUpper() == SolutionFolder)
-                    list.AddRange(GetFolderProjects(project));
-                else
-                    list.Add(project);
-            }
-
-            return list;
-        }
-
-        private static IEnumerable<Project> GetFolderProjects(Project folder)
-        {
-            var list = new List<Project>();
-
-            foreach (ProjectItem item in folder.ProjectItems)
-            {
-                var subProject = item.SubProject;
-
-                if (subProject == null) continue;
-
-                if (subProject.Kind.ToUpper() == SolutionFolder)
-                    list.AddRange(GetFolderProjects(subProject));
-                else
-                    list.Add(subProject);
-            }
-
-            return list;
-        }
-
+        
         private void SolutionProjectAdded(Project project)
         {
             //Don't want to include the VS Miscellaneous Files Project - which appears occasionally and during a diff operation

--- a/ReportDeployer/ReportList.xaml.cs
+++ b/ReportDeployer/ReportList.xaml.cs
@@ -87,7 +87,7 @@ namespace ReportDeployer
         private void RegisterProjectEvents()
         {
             //Manually register the OnAfterOpenProject event on the existing projects as they are already opened by the time the event would normally be registered
-            foreach (Project project in ConnPane.Projects)
+            foreach (Project project in SharedWindow.GetProjects(ConnPane.Projects))
             {
                 IVsHierarchy projectHierarchy;
                 if (_vsSolution.GetProjectOfUniqueName(project.UniqueName, out projectHierarchy) != VSConstants.S_OK)
@@ -288,7 +288,7 @@ namespace ReportDeployer
 
         private Project GetProjectByName(string projectName)
         {
-            foreach (Project project in ConnPane.Projects)
+            foreach (Project project in SharedWindow.GetProjects(ConnPane.Projects))
             {
                 if (project.Name != projectName) continue;
 

--- a/SolutionPackager/SolutionList.xaml.cs
+++ b/SolutionPackager/SolutionList.xaml.cs
@@ -293,7 +293,7 @@ namespace SolutionPackager
                 doc.Load(path + "\\CRMDeveloperExtensions.config");
 
                 List<string> projectNames = new List<string>();
-                foreach (Project p in ConnPane.Projects)
+                foreach (Project p in SharedWindow.GetProjects(ConnPane.Projects))
                 {
                     projectNames.Add(p.Name.ToUpper());
                 }
@@ -373,7 +373,8 @@ namespace SolutionPackager
 
         private Project GetProjectByName(string projectName)
         {
-            foreach (Project project in ConnPane.Projects)
+            var projects = SharedWindow.GetProjects(ConnPane.Projects);
+            foreach (Project project in projects)
             {
                 if (project.Name != projectName) continue;
 


### PR DESCRIPTION
Fixed issue where projects in solution folders aren't displayed at all in Plugin Deployer. 

Refactored code that loops through projects so that it calls shared function SharedWindow.GetProjects that will get all Projects within solution folders. Projects now ordered by Name when retrieved from SharedWindow.GetProjects.